### PR TITLE
Fix error when requesting twitter avatar path

### DIFF
--- a/views/application.coffee
+++ b/views/application.coffee
@@ -228,7 +228,8 @@ class Tweet
 
   profile_image_url: ->
     return "http://a0.twimg.com/sticky/default_profile_images/default_profile_4_mini.png" unless @status.profile_image_url?
-    @status.profile_image_url.replace('_normal','_mini')
+    profile_image_url = @status.profile_image_url
+    '//' + profile_image_url.host + profile_image_url.path.replace('_normal','_mini')
 
   created_at: ->
     return "#" unless @status.created_at?


### PR DESCRIPTION
Currently when going to a detail page the Twitter feed won't load due to an error (profile_image_url is an object, not a string). This fixes that issue and will make tweets load again.
